### PR TITLE
allow mismatch between bin name and what's in cue

### DIFF
--- a/cue.h
+++ b/cue.h
@@ -91,6 +91,7 @@ enum {
 
 struct cue_file {
     char* name;
+    char* name_backup;
     int buf_mode;
     void* buf;
     size_t size;


### PR DESCRIPTION
I've run into some cue files where the bin/cue have been renamed so the bin name defined in the cue sheet is wrong. In this case, attempt a fallback where we assume the bin name is the same as the cue filename. This won't work for cases where we have multiple bins per cue, but for a single-track CDROM, its nice to have.